### PR TITLE
Add FlappyHalcon game and marketing plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# FlappyHalcon
+
+**Slogan:** "Con esfuerzo y alas, se llega lejos en la UTEZ"
+
+## Público objetivo
+Toda la comunidad de la Universidad Tecnológica de Emiliano Zapata (UTEZ), desde estudiantes de nuevo ingreso hasta egresados y personal docente.
+
+## Diferenciador
+FlappyHalcon es un juego institucional divertido que refleja situaciones reales de los estudiantes UTEZ. Combina la mecánica clásica de Flappy Bird con obstáculos alusivos a la vida académica como exámenes sorpresa y distracciones cotidianas.
+
+## Visual
+El halcón mascota vuela entre los edificios de *Docencias* representados con los colores oficiales (#199779 y #093565). A medida que avanza esquiva exámenes, celulares, fiestas y tentaciones tecnológicas. Algunos ítems de bonificación simbolizan motivación y superación.
+
+## Diseño gráfico
+- Colores predominantes: verde #199779 y azul #093565.
+- Estilo académico ligero con referencias a la vida estudiantil.
+- Logotipo institucional (por agregar) se puede colocar en la esquina superior.
+
+## Vínculo con identidad UTEZ
+El personaje principal es el halcón, mascota oficial. Los obstáculos y bonificaciones representan esfuerzos y distracciones reales de los alumnos. Los edificios de Docencias aparecen como parte del escenario reforzando el sentido de pertenencia.
+
+## Pitch (menos de 1 minuto)
+
+FlappyHalcon es un juego web inspirado en la dinámica de Flappy Bird pero protagonizado por el halcón de la UTEZ. El jugador debe mantener al halcón en vuelo mientras esquiva exámenes sorpresa, celulares, fiestas y tentaciones de IA. Con cada salto gasta energía, reflejo del esfuerzo académico, y al recolectar bonificaciones recupera motivación y vidas. El objetivo es llegar lo más lejos posible a través de diez niveles de dificultad creciente. Con un estilo sencillo y colores institucionales, FlappyHalcon busca motivar y divertir a toda la comunidad UTEZ recordando que, con esfuerzo y alas, se llega lejos.

--- a/index.html
+++ b/index.html
@@ -22,6 +22,14 @@
     const canvas = document.getElementById("gameCanvas");
     const ctx = canvas.getContext("2d");
 
+    const MAX_LEVEL = 10;
+    const obstacleTypes = [
+      { color: '#FF5555', label: 'Examen' },
+      { color: '#999999', label: 'Celular' },
+      { color: '#F4A460', label: 'Cerveza' },
+      { color: '#9932CC', label: 'IA' }
+    ];
+
     let halcon = {
       x: 80,
       y: 150,
@@ -42,21 +50,31 @@
     let isGameOver = false;
 
     function drawHalcon() {
-      ctx.fillStyle = "#FFD700";
+      ctx.fillStyle = '#FFD700';
       ctx.fillRect(halcon.x, halcon.y, halcon.width, halcon.height);
     }
 
     function drawObstacle(obstacle) {
-      ctx.fillStyle = "#000";
+      ctx.fillStyle = obstacle.type.color;
       ctx.fillRect(obstacle.x, 0, obstacle.width, obstacle.top);
       ctx.fillRect(obstacle.x, canvas.height - obstacle.bottom, obstacle.width, obstacle.bottom);
+      ctx.fillStyle = 'white';
+      ctx.font = '12px Arial';
+      ctx.fillText(obstacle.type.label, obstacle.x + 5, obstacle.top - 5);
     }
 
     function drawBonus(bonus) {
-      ctx.fillStyle = "#00FF00";
+      ctx.fillStyle = '#00FF00';
       ctx.beginPath();
       ctx.arc(bonus.x, bonus.y, bonus.radius, 0, Math.PI * 2);
       ctx.fill();
+    }
+
+    function drawBuilding() {
+      ctx.fillStyle = '#093565';
+      ctx.fillRect(0, canvas.height - 60, canvas.width, 60);
+      ctx.fillStyle = '#FFFFFF';
+      ctx.fillText('Docencias', 10, canvas.height - 10);
     }
 
     function update() {
@@ -65,9 +83,18 @@
       halcon.velocity += halcon.gravity;
       halcon.y += halcon.velocity;
 
-      if (halcon.energy > 0 && keys["ArrowRight"]) {
-        halcon.x += 3;
+      let baseSpeed = 2 + level * 0.5;
+      let boost = 0;
+      if (halcon.energy > 0 && keys['ArrowRight']) {
+        boost = 2;
         halcon.energy -= 0.5;
+      } else {
+        halcon.energy = Math.min(100, halcon.energy + 0.1);
+      }
+
+      if ((keys[' '] || keys['ArrowUp']) && halcon.energy > 0) {
+        halcon.velocity = halcon.lift;
+        halcon.energy -= 1;
       }
 
       if (halcon.y + halcon.height > canvas.height || halcon.y < 0) {
@@ -76,26 +103,28 @@
 
       if (frame % 100 === 0) {
         let gap = 140 - level * 10;
+        if (gap < 60) gap = 60;
         let topHeight = Math.floor(Math.random() * (canvas.height - gap - 100)) + 20;
         let bottomHeight = canvas.height - topHeight - gap;
         obstacles.push({
           x: canvas.width,
           width: 60,
           top: topHeight,
-          bottom: bottomHeight
+          bottom: bottomHeight,
+          type: obstacleTypes[Math.floor(Math.random() * obstacleTypes.length)]
         });
       }
 
       if (frame % 250 === 0) {
         bonusItems.push({
           x: canvas.width,
-          y: Math.random() * canvas.height,
+          y: Math.random() * (canvas.height - 100) + 50,
           radius: 10
         });
       }
 
       obstacles.forEach((obstacle, index) => {
-        obstacle.x -= 2 + level * 0.5;
+        obstacle.x -= baseSpeed + boost;
         if (
           halcon.x < obstacle.x + obstacle.width &&
           halcon.x + halcon.width > obstacle.x &&
@@ -106,12 +135,12 @@
         if (obstacle.x + obstacle.width < 0) {
           obstacles.splice(index, 1);
           halcon.score++;
-          if (halcon.score % 5 === 0) level++;
+          if (halcon.score % 5 === 0 && level < MAX_LEVEL) level++;
         }
       });
 
       bonusItems.forEach((bonus, index) => {
-        bonus.x -= 2;
+        bonus.x -= baseSpeed + boost;
         if (
           halcon.x < bonus.x + bonus.radius &&
           halcon.x + halcon.width > bonus.x - bonus.radius &&
@@ -131,22 +160,23 @@
       halcon.velocity = 0;
       if (halcon.lives <= 0) {
         isGameOver = true;
-        alert("¡Game Over! Puntuación: " + halcon.score);
+        alert('¡Game Over! Puntuación: ' + halcon.score);
         location.reload();
       }
     }
 
     function drawUI() {
-      ctx.fillStyle = "white";
-      ctx.font = "16px Arial";
-      ctx.fillText("Vidas: " + halcon.lives, 10, 20);
-      ctx.fillText("Energía: " + Math.floor(halcon.energy), 10, 40);
-      ctx.fillText("Nivel: " + level, 10, 60);
-      ctx.fillText("Puntos: " + halcon.score, 10, 80);
+      ctx.fillStyle = 'white';
+      ctx.font = '16px Arial';
+      ctx.fillText('Vidas: ' + halcon.lives, 10, 20);
+      ctx.fillText('Energía: ' + Math.floor(halcon.energy), 10, 40);
+      ctx.fillText('Nivel: ' + level, 10, 60);
+      ctx.fillText('Puntos: ' + halcon.score, 10, 80);
     }
 
     function draw() {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
+      drawBuilding();
       drawHalcon();
       obstacles.forEach(drawObstacle);
       bonusItems.forEach(drawBonus);
@@ -161,11 +191,12 @@
     }
 
     const keys = {};
-    window.addEventListener("keydown", e => {
+    window.addEventListener('keydown', e => {
       keys[e.key] = true;
-      if (e.key === " " || e.key === "ArrowUp") halcon.velocity = halcon.lift;
     });
-    window.addEventListener("keyup", e => keys[e.key] = false);
+    window.addEventListener('keyup', e => {
+      keys[e.key] = false;
+    });
 
     gameLoop();
   </script>


### PR DESCRIPTION
## Summary
- implement FlappyHalcon game with life and energy system
- include 10 levels with themed obstacles and bonus items
- add building and institutional colors
- document marketing campaign and pitch in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684a03a3a24c8329b8df4e375ad45a59